### PR TITLE
Access matrix dimensions using 'cols' and 'rows'

### DIFF
--- a/generator.class.rb
+++ b/generator.class.rb
@@ -407,7 +407,7 @@ class MockMAVL
 				entrytype = Type.new([:intvec, :floatvec].sample, xDim)
 				return "#{generateDotProd(entrytype)} .dimension"
 			else
-				xy = [".xDimension", ".yDimension"].sample
+				xy = [".rows", ".cols"].sample
 				entrytype = Type.new([:intmat, :floatmat].sample, xDim, yDim)
 				return "#{generateDotProd(entrytype)} #{xy}"
 			end


### PR DESCRIPTION
In the current version of MAVL, matrix x/y-dimensions are accessed using `.cols` and `.rows` instead of `xDimension` and `yDimension`.